### PR TITLE
fix(Configurator): prevent exception with null interactable

### DIFF
--- a/Runtime/SharedResources/Scripts/InteractableHighlighterConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/InteractableHighlighterConfigurator.cs
@@ -181,6 +181,11 @@
         /// <param name="interactable">The source of the interaction events.</param>
         protected virtual void RegisterInteractableEvents(InteractableFacade interactable)
         {
+            if (interactable == null)
+            {
+                return;
+            }
+
             interactable.FirstTouched.AddListener(HandleFirstTouched);
             interactable.LastUntouched.AddListener(HandleLastUntouched);
             interactable.FirstGrabbed.AddListener(HandleFirstGrabbed);
@@ -193,6 +198,11 @@
         /// <param name="interactable">The source of the interaction events.</param>
         protected virtual void UnregisterInteractableEvents(InteractableFacade interactable)
         {
+            if (interactable == null)
+            {
+                return;
+            }
+
             interactable.FirstTouched.RemoveListener(HandleFirstTouched);
             interactable.LastUntouched.RemoveListener(HandleLastUntouched);
             interactable.FirstGrabbed.RemoveListener(HandleFirstGrabbed);


### PR DESCRIPTION
If the passed interactable is not set then a null exception could
occur. This fix simply defends against a null interactable and prevents
the exception error.